### PR TITLE
security: gate deploy + release with 2/2 admin approval

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,16 +1,13 @@
 name: Build & Deploy
-
 on:
   push:
     branches: [main]
     tags: ['v*']
   pull_request:
     branches: [main]
-
 permissions:
   contents: write
   deployments: write
-
 jobs:
   build-web:
     runs-on: ubuntu-latest
@@ -77,6 +74,7 @@ jobs:
     needs: build-web
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     runs-on: ubuntu-latest
+    environment: production
     steps:
       - uses: actions/download-artifact@v4
         with:
@@ -92,6 +90,7 @@ jobs:
     needs: [build-web, build-tui]
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
+    environment: release
     steps:
       - uses: actions/download-artifact@v4
       - name: Create Release


### PR DESCRIPTION
### Changes
- `deploy` job: `environment: production` (requires bmorphism + zubyul approval)
- `release` job: `environment: release` (requires bmorphism + zubyul approval)
- `prevent_self_review: true` on both environments
- Commit signatures now required on main
- Tag ruleset protects `v*` tags from unauthorized creation/deletion

### Security posture after merge

| Gate | Reviewers | Self-review |
|------|-----------|-------------|
| PR to main | 2/2 | allowed |
| Deploy to CF Pages | 2/2 admin | blocked |
| Release (tag push) | 2/2 admin | blocked |
| Commit signatures | required | — |
| Tag creation `v*` | blocked | — |

No code ships without 2 admin confirmations.