### PR TITLE
replace proper names with deterministic colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,26 @@
-# nash-portal
+# ◈
+
+## Color legend
+
+Proper names in this codebase resolve through `SplitMix64(seed = 1069) → HSL(0.75, 0.55) → RGB`:
+
+| was | sigil | hex |
+|---|---|---|
+| NASH | ◆ | `#E23C36` |
+| SOL / POOL | ◇ | `#36E2A3` |
+| pump.fun | ✦ | `#E23653` |
+| GeckoTerminal | ⬢ | `#E23667` |
+| Jupiter | ✧ | `#AC36E2` |
+| DexScreener | ✿ | `#C836E2` |
+| Plurigrid | ⬡ | `#E25936` |
+| nash-portal / NASH Portal | ◈ | `#E27B36` |
 
 ## Post-web thesis
 
-The browser was the wrong cathedral. It fused identity, rendering, capability, and payment into a single opaque binary governed by ad-tech. `nash-portal` is built on the inverse premise: **one UI, two surfaces, no backend, no secrets**.
+The browser was the wrong cathedral. It fused identity, rendering, capability, and payment into a single opaque binary governed by ad-tech. `◈` is built on the inverse premise: **one UI, two surfaces, no backend, no secrets**.
 
 - **Rendering is a commodity.** The same ratatui widget tree paints a terminal (`tui/`) and a WASM canvas (`web/`). Neither surface is privileged; the TUI is the reference.
-- **Data is public or it is not data.** OHLCV streams from GeckoTerminal's public API. No keys, no auth, no server-side state. If a feed needs a secret, it doesn't belong in the portal.
+- **Data is public or it is not data.** OHLCV streams from `⬢`'s public API. No keys, no auth, no server-side state. If a feed needs a secret, it doesn't belong in the portal.
 - **Identity is on-chain or it is off-channel.** No accounts, no sign-ins, no cookies. Wallet facts (Neversold predicate, Tier-S exclusion, Scheme-C eligibility) are computed from the chain, not claimed by a server.
 - **The portal is a lens, not a platform.** It does not custody, broker, or route. It renders a token's public state and the cohort-level consequences of the Neversold predicate.
 - **Releases are artifacts, not services.** `gh release` ships three signed tarballs and one WASM bundle. Uptime is a property of Cloudflare Pages + the user's terminal; there is nothing to operate.
@@ -17,12 +32,12 @@ Post-web means: the useful half of a web app (pixels on a grid, live data, a lin
 - **web** — [ratzilla](https://github.com/orhun/ratzilla) WASM build, deployed to Cloudflare Pages
 - **tui** — native [ratatui](https://github.com/ratatui/ratatui) binary for macOS / Linux
 
-OHLCV candles stream from the public GeckoTerminal API. No keys, no backend.
+OHLCV candles stream from the public `⬢` API. No keys, no backend.
 
 ## Layout
 
 ```
-nash-portal/
+◈/
 ├── Cargo.toml      # workspace: [web, tui]
 ├── web/            # ratzilla 0.3 → wasm32-unknown-unknown, built with trunk
 └── tui/            # ratatui 0.30 + crossterm 0.28, native
@@ -52,8 +67,10 @@ CI (`.github/workflows/`) handles:
 
 Required secrets: `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`.
 
+(The Cloudflare project name `nash-portal` is preserved as a functional identifier — external infrastructure config.)
+
 ## Token
 
-NASH mint: `4DQsMSkeKc3Mcij1BE4Z8oqU3QeV45QQ3Psn3CNDpump` (pump.fun, ossified).
+`◆` mint: `4DQsMSkeKc3Mcij1BE4Z8oqU3QeV45QQ3Psn3CNDpump` (`✦`, ossified).
 
 Neversold cohort and Scheme-C forfeiture detail: see release notes on each `v*` tag.

--- a/justfile
+++ b/justfile
@@ -1,0 +1,24 @@
+default:
+    @just --list --unsorted
+
+# run the TUI (debug build, fastest feedback)
+nash:
+    cargo run -p nash-portal-tui
+
+# release build + run the TUI
+nash-release:
+    cargo run --release -p nash-portal-tui
+
+# serve the ratzilla web build at http://127.0.0.1:8080
+web:
+    cd web && trunk serve --open
+
+# cargo check both packages
+check:
+    cargo check -p nash-portal-tui
+    cargo check -p nash-portal-web --target wasm32-unknown-unknown
+
+# release build both
+build:
+    cargo build --release -p nash-portal-tui
+    cd web && trunk build --release

--- a/tui/src/main.rs
+++ b/tui/src/main.rs
@@ -16,8 +16,18 @@ use ratatui::{
 use std::{io, sync::Arc, time::Duration};
 use tokio::sync::Mutex;
 
-const NASH: &str = "4DQsMSkeKc3Mcij1BE4Z8oqU3QeV45QQ3Psn3CNDpump";
-const POOL: &str = "FwuB9juwaoo35C2Nx6XMVn3sQ6B9HeXuuquR7rB21y3Y";
+// proper names → SplitMix64(seed = 1069) → HSL(s=0.75, l=0.55) → RGB.
+const X_E23C36: Color = Color::Rgb(226,  60,  54); // ◆  formerly NASH
+const X_36E2A3: Color = Color::Rgb( 54, 226, 163); // ◇  formerly SOL / POOL
+const X_E23653: Color = Color::Rgb(226,  54,  83); // ✦  formerly pump.fun
+const X_E23667: Color = Color::Rgb(226,  54, 103); // ⬢  formerly GeckoTerminal
+const X_E25936: Color = Color::Rgb(226,  89,  54); // ⬡  formerly Plurigrid
+const X_E27B36: Color = Color::Rgb(226, 123,  54); // ◈  formerly NASH Portal / TUI
+const X_AC36E2: Color = Color::Rgb(172,  54, 226); // ✧  formerly Jupiter
+const X_C836E2: Color = Color::Rgb(200,  54, 226); // ✿  formerly DexScreener
+
+const X_E23C36_ADDR: &str = "4DQsMSkeKc3Mcij1BE4Z8oqU3QeV45QQ3Psn3CNDpump";
+const X_36E2A3_ADDR: &str = "FwuB9juwaoo35C2Nx6XMVn3sQ6B9HeXuuquR7rB21y3Y";
 
 #[derive(Default, Clone)]
 struct TokenData {
@@ -67,7 +77,7 @@ impl App {
     fn ticker_text(&self) -> String {
         let d = &self.data;
         let a = |v: f64| if v > 0.0 {"▲"} else if v < 0.0 {"▼"} else {"─"};
-        format!("    NASH ${:.8}  {}5m {:+.1}%  {}1h {:+.1}%  {}24h {:+.1}%  │  MCap ${:.0}K  Vol ${:.0}K  │  B:{} S:{}  │  {:.6} SOL  ◆  pump.fun    ",
+        format!("    ◆ ${:.8}  {}5m {:+.1}%  {}1h {:+.1}%  {}24h {:+.1}%  │  MCap ${:.0}K  Vol ${:.0}K  │  B:{} S:{}  │  {:.6} ◇  ✦    ",
             d.price_usd, a(d.change_5m), d.change_5m, a(d.change_1h), d.change_1h,
             a(d.change_24h), d.change_24h, d.market_cap/1000.0, d.volume_24h/1000.0,
             d.buys_24h, d.sells_24h, d.price_sol)
@@ -115,13 +125,13 @@ fn parse_geckoterminal(v: &serde_json::Value) -> Result<Vec<Candle>, &'static st
 }
 
 async fn fetch_dexscreener() -> Result<TokenData, Box<dyn std::error::Error + Send + Sync>> {
-    let v: serde_json::Value = reqwest::get(&format!("https://api.dexscreener.com/latest/dex/tokens/{}", NASH)).await?.json().await?;
+    let v: serde_json::Value = reqwest::get(&format!("https://api.dexscreener.com/latest/dex/tokens/{}", X_E23C36_ADDR)).await?.json().await?;
     parse_dexscreener(&v).map_err(|e| e.into())
 }
 
 async fn fetch_jupiter_price() -> Result<f64, Box<dyn std::error::Error + Send + Sync>> {
-    let v: serde_json::Value = reqwest::get(&format!("https://api.jup.ag/price/v2?ids={}", NASH)).await?.json().await?;
-    parse_jupiter_price(&v, NASH).map_err(|e| e.into())
+    let v: serde_json::Value = reqwest::get(&format!("https://api.jup.ag/price/v2?ids={}", X_E23C36_ADDR)).await?.json().await?;
+    parse_jupiter_price(&v, X_E23C36_ADDR).map_err(|e| e.into())
 }
 
 fn period_secs(tf: Timeframe) -> u64 {
@@ -134,7 +144,7 @@ fn jitter(base: u64) -> Duration {
 
 async fn fetch_candles(tf: Timeframe) -> Result<Vec<Candle>, Box<dyn std::error::Error + Send + Sync>> {
     let (period, agg, limit) = tf.api_params();
-    let url = format!("https://api.geckoterminal.com/api/v2/networks/solana/pools/{}/ohlcv/{}?aggregate={}&limit={}&currency=usd", POOL, period, agg, limit);
+    let url = format!("https://api.geckoterminal.com/api/v2/networks/solana/pools/{}/ohlcv/{}?aggregate={}&limit={}&currency=usd", X_36E2A3_ADDR, period, agg, limit);
     let v: serde_json::Value = reqwest::get(&url).await?.json().await?;
     parse_geckoterminal(&v).map_err(|e| e.into())
 }
@@ -148,7 +158,12 @@ fn epsilon_greedy_jupiter(roll: f32) -> bool { roll < 0.9 }
 
 fn render_candles(f: &mut Frame, area: ratatui::layout::Rect, candles: &[Candle], tf: Timeframe) {
     if candles.is_empty() {
-        f.render_widget(Paragraph::new("  Loading candles from GeckoTerminal...")
+        let loading = Line::from(vec![
+            Span::raw("  Loading candles from "),
+            Span::styled("⬢", Style::default().fg(X_E23667).add_modifier(Modifier::BOLD)),
+            Span::raw("..."),
+        ]);
+        f.render_widget(Paragraph::new(loading)
             .block(Block::default().borders(Borders::ALL).title(" Candles ")), area);
         return;
     }
@@ -256,10 +271,14 @@ fn draw(f: &mut Frame, app: &App) {
     // Price
     let pc = if app.data.change_5m > 0.0 {Color::Green} else if app.data.change_5m < 0.0 {Color::Red} else {Color::White};
     f.render_widget(Paragraph::new(Line::from(vec![
-        Span::styled(" NASH ", Style::default().fg(Color::White).bg(Color::Magenta).add_modifier(Modifier::BOLD)),
+        Span::styled(" ◆ ", Style::default().fg(Color::Black).bg(X_E23C36).add_modifier(Modifier::BOLD)),
         Span::styled(format!("  ${:.8}", app.data.price_usd), Style::default().fg(pc).add_modifier(Modifier::BOLD)),
-        Span::styled(format!("  {:.6} SOL", app.data.price_sol), Style::default().fg(Color::Cyan)),
-        Span::styled(format!("  MCap ${:.0}K  FDV ${:.0}K", app.data.market_cap/1000.0, app.data.fdv/1000.0), Style::default().fg(Color::Yellow)),
+        Span::raw("  "),
+        Span::styled(format!("{:.6}", app.data.price_sol), Style::default().fg(X_36E2A3)),
+        Span::raw(" "),
+        Span::styled("◇", Style::default().fg(X_36E2A3).add_modifier(Modifier::BOLD)),
+        Span::styled(format!("  MCap ${:.0}K  FDV ${:.0}K  ", app.data.market_cap/1000.0, app.data.fdv/1000.0), Style::default().fg(Color::Yellow)),
+        Span::styled("✦", Style::default().fg(X_E23653).add_modifier(Modifier::BOLD)),
         Span::styled(format!("  │ {}", app.status), Style::default().fg(Color::DarkGray)),
     ])).block(Block::default().borders(Borders::ALL).border_style(Style::default().fg(Color::DarkGray))), outer[1]);
 
@@ -303,7 +322,12 @@ fn draw(f: &mut Frame, app: &App) {
         Span::styled(" q", Style::default().fg(Color::Yellow)), Span::raw(":quit "),
         Span::styled("t", Style::default().fg(Color::Yellow)), Span::raw(":timeframe "),
         Span::styled("r", Style::default().fg(Color::Yellow)), Span::raw(":refresh "),
-        Span::raw(format!(" │ [{}] │ tick {} │ GeckoTerminal OHLCV", app.timeframe.label(), app.tick)),
+        Span::raw(format!(" │ [{}] │ tick {} │ ", app.timeframe.label(), app.tick)),
+        Span::styled("⬢", Style::default().fg(X_E23667).add_modifier(Modifier::BOLD)),
+        Span::raw(" OHLCV │ "),
+        Span::styled("⬡", Style::default().fg(X_E25936).add_modifier(Modifier::BOLD)),
+        Span::raw(" "),
+        Span::styled("◈", Style::default().fg(X_E27B36).add_modifier(Modifier::BOLD)),
     ])).style(Style::default().fg(Color::DarkGray)), outer[5]);
 }
 
@@ -323,12 +347,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 if let Ok(px) = fetch_jupiter_price().await {
                     let mut a = ac_p.lock().await;
                     a.data.price_usd = px;
-                    a.status = format!("jup ${:.8}", px);
+                    a.status = format!("✧ ${:.8}", px);
                 }
             } else if let Ok(d) = fetch_dexscreener().await {
                 let mut a = ac_p.lock().await;
                 a.data = d;
-                a.status = "dex (probe)".into();
+                a.status = "✿ (probe)".into();
             }
             tokio::time::sleep(Duration::from_millis(5000 + fastrand::u64(0..2000))).await;
         }
@@ -434,7 +458,7 @@ mod tests {
         }]})
     }
     fn jup_fixture(px: &str) -> serde_json::Value {
-        json!({"data":{ NASH: { "price": px } }})
+        json!({"data":{ X_E23C36_ADDR: { "price": px } }})
     }
     fn gt_fixture(rows: &[(i64,f64,f64,f64,f64,f64)]) -> serde_json::Value {
         let arr: Vec<serde_json::Value> = rows.iter()
@@ -453,7 +477,7 @@ mod tests {
     }
     #[test]
     fn jup_fixture_parses() {
-        let p = parse_jupiter_price(&jup_fixture("0.00009"), NASH).unwrap();
+        let p = parse_jupiter_price(&jup_fixture("0.00009"), X_E23C36_ADDR).unwrap();
         assert!((p - 9e-5).abs() < 1e-12);
     }
     #[test]
@@ -471,10 +495,10 @@ mod tests {
         let v = json!({"pairs":[{"priceUsd":"NOT_A_NUMBER","txns":{"h24":{"buys":0,"sells":0}}}]});
         assert_eq!(parse_dexscreener(&v).unwrap().price_usd, 0.0);
     }
-    #[test] fn jup_missing_mint_is_err()      { assert!(parse_jupiter_price(&json!({"data":{}}), NASH).is_err()); }
+    #[test] fn jup_missing_mint_is_err()      { assert!(parse_jupiter_price(&json!({"data":{}}), X_E23C36_ADDR).is_err()); }
     #[test] fn jup_numeric_instead_of_str_is_err() {
-        let v = json!({"data":{ NASH: { "price": 0.0001 }}});
-        assert!(parse_jupiter_price(&v, NASH).is_err());
+        let v = json!({"data":{ X_E23C36_ADDR: { "price": 0.0001 }}});
+        assert!(parse_jupiter_price(&v, X_E23C36_ADDR).is_err());
     }
     #[test] fn gt_short_row_is_skipped_not_panic() {
         let v = json!({"data":{"attributes":{"ohlcv_list":[[1,2,3]]}}});

--- a/web/index.html
+++ b/web/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8"/>
     <link data-trunk rel="rust"/>
-    <title>NASH Portal</title>
+    <title>◈</title>
     <style>
       body {
         margin: 0;
@@ -62,7 +62,7 @@ color: #000;
 <div class="dl"><a href="https://github.com/plurigrid/nash-portal/releases/latest">download tui</a></div>
     <script type="module">
       window.addEventListener("TrunkApplicationStarted", (_) => {
-        console.log("NASH Portal initialized");
+        console.log("◈ initialized");
       });
     </script>
 </body>

--- a/web/src/main.rs
+++ b/web/src/main.rs
@@ -12,8 +12,19 @@ use ratzilla::ratatui::{
 use ratzilla::{event::KeyCode, DomBackend, WebRenderer};
 use wasm_bindgen_futures::spawn_local;
 
-const NASH: &str = "4DQsMSkeKc3Mcij1BE4Z8oqU3QeV45QQ3Psn3CNDpump";
-const POOL: &str = "FwuB9juwaoo35C2Nx6XMVn3sQ6B9HeXuuquR7rB21y3Y";
+// proper names → SplitMix64(seed = 1069) → HSL(s=0.75, l=0.55) → RGB.
+// Each color is the deterministic image of the name it replaces.
+const X_E23C36: Color = Color::Rgb(226,  60,  54); // ◆  formerly NASH
+const X_36E2A3: Color = Color::Rgb( 54, 226, 163); // ◇  formerly SOL / POOL
+const X_E23653: Color = Color::Rgb(226,  54,  83); // ✦  formerly pump.fun
+const X_E23667: Color = Color::Rgb(226,  54, 103); // ⬢  formerly GeckoTerminal
+const X_E25936: Color = Color::Rgb(226,  89,  54); // ⬡  formerly Plurigrid
+const X_E27B36: Color = Color::Rgb(226, 123,  54); // ◈  formerly NASH Portal
+const X_AC36E2: Color = Color::Rgb(172,  54, 226); // ✧  formerly Jupiter
+const X_C836E2: Color = Color::Rgb(200,  54, 226); // ✿  formerly DexScreener
+
+const X_E23C36_ADDR: &str = "4DQsMSkeKc3Mcij1BE4Z8oqU3QeV45QQ3Psn3CNDpump";
+const X_36E2A3_ADDR: &str = "FwuB9juwaoo35C2Nx6XMVn3sQ6B9HeXuuquR7rB21y3Y";
 
 #[derive(Default, Clone)]
 struct TokenData {
@@ -113,7 +124,7 @@ impl App {
             }
         };
         format!(
-            "    NASH ${:.8}  {}5m {:+.1}%  {}1h {:+.1}%  {}24h {:+.1}%  │  MCap ${:.0}K  Vol ${:.0}K  │  B:{} S:{}  │  {:.6} SOL  ◆  pump.fun    ",
+            "    ◆ ${:.8}  {}5m {:+.1}%  {}1h {:+.1}%  {}24h {:+.1}%  │  MCap ${:.0}K  Vol ${:.0}K  │  B:{} S:{}  │  {:.6} ◇  ✦    ",
             d.price_usd,
             arrow(d.change_5m),
             d.change_5m,
@@ -185,17 +196,17 @@ fn parse_geckoterminal(v: &serde_json::Value) -> Result<Vec<Candle>, &'static st
 }
 
 async fn fetch_dexscreener() -> Option<TokenData> {
-    let url = format!("https://api.dexscreener.com/latest/dex/tokens/{}", NASH);
+    let url = format!("https://api.dexscreener.com/latest/dex/tokens/{}", X_E23C36_ADDR);
     let resp = gloo_net::http::Request::get(&url).send().await.ok()?;
     let v: serde_json::Value = resp.json().await.ok()?;
     parse_dexscreener(&v).ok()
 }
 
 async fn fetch_jupiter_price() -> Option<f64> {
-    let url = format!("https://api.jup.ag/price/v2?ids={}", NASH);
+    let url = format!("https://api.jup.ag/price/v2?ids={}", X_E23C36_ADDR);
     let resp = gloo_net::http::Request::get(&url).send().await.ok()?;
     let v: serde_json::Value = resp.json().await.ok()?;
-    parse_jupiter_price(&v, NASH).ok()
+    parse_jupiter_price(&v, X_E23C36_ADDR).ok()
 }
 
 fn period_millis(tf: Timeframe) -> u32 {
@@ -225,7 +236,7 @@ async fn fetch_candles(tf: Timeframe) -> Option<Vec<Candle>> {
     let (period, agg, limit) = tf.api_params();
     let url = format!(
         "https://api.geckoterminal.com/api/v2/networks/solana/pools/{}/ohlcv/{}?aggregate={}&limit={}&currency=usd",
-        POOL, period, agg, limit
+        X_36E2A3_ADDR, period, agg, limit
     );
     let resp = gloo_net::http::Request::get(&url).send().await.ok()?;
     let v: serde_json::Value = resp.json().await.ok()?;
@@ -269,12 +280,12 @@ fn spawn_fast_price_loop(state: &Rc<RefCell<App>>) {
                 if let Some(px) = fetch_jupiter_price().await {
                     let mut app = state.borrow_mut();
                     app.data.price_usd = px;
-                    app.status = format!("jup ${:.8}", px);
+                    app.status = format!("✧ ${:.8}", px);
                 }
             } else if let Some(data) = fetch_dexscreener().await {
                 let mut app = state.borrow_mut();
                 app.data = data;
-                app.status = "dex (probe)".into();
+                app.status = "✿ (probe)".into();
             }
 
             TimeoutFuture::new(5_000 + random_millis(2_001)).await;
@@ -324,8 +335,13 @@ fn spawn_candle_loop(state: &Rc<RefCell<App>>) {
 
 fn render_candles(f: &mut Frame, area: Rect, candles: &[Candle], tf: Timeframe) {
     if candles.is_empty() {
+        let loading = Line::from(vec![
+            Span::raw("  Loading candles from "),
+            Span::styled("⬢", Style::default().fg(X_E23667).add_modifier(Modifier::BOLD)),
+            Span::raw("..."),
+        ]);
         f.render_widget(
-            Paragraph::new("  Loading candles from GeckoTerminal...")
+            Paragraph::new(loading)
                 .block(Block::default().borders(Borders::ALL).title(" Candles ")),
             area,
         );
@@ -500,28 +516,29 @@ fn draw(f: &mut Frame, app: &App) {
     f.render_widget(
         Paragraph::new(Line::from(vec![
             Span::styled(
-                " NASH ",
+                " ◆ ",
                 Style::default()
-                    .fg(Color::White)
-                    .bg(Color::Magenta)
+                    .fg(Color::Black)
+                    .bg(X_E23C36)
                     .add_modifier(Modifier::BOLD),
             ),
             Span::styled(
                 format!("  ${:.8}", d.price_usd),
                 Style::default().fg(pc).add_modifier(Modifier::BOLD),
             ),
-            Span::styled(
-                format!("  {:.6} SOL", d.price_sol),
-                Style::default().fg(Color::Cyan),
-            ),
+            Span::raw("  "),
+            Span::styled(format!("{:.6}", d.price_sol), Style::default().fg(X_36E2A3)),
+            Span::raw(" "),
+            Span::styled("◇", Style::default().fg(X_36E2A3).add_modifier(Modifier::BOLD)),
             Span::styled(
                 format!(
-                    "  MCap ${:.0}K  FDV ${:.0}K",
+                    "  MCap ${:.0}K  FDV ${:.0}K  ",
                     d.market_cap / 1000.0,
                     d.fdv / 1000.0
                 ),
                 Style::default().fg(Color::Yellow),
             ),
+            Span::styled("✦", Style::default().fg(X_E23653).add_modifier(Modifier::BOLD)),
             Span::styled(
                 format!("  │ {}", app.status),
                 Style::default().fg(Color::DarkGray),
@@ -649,11 +666,16 @@ fn draw(f: &mut Frame, app: &App) {
             Span::raw(":timeframe "),
             Span::styled("r", Style::default().fg(Color::Yellow)),
             Span::raw(":refresh "),
-            Span::raw(format!(
-                " │ [{}] │ tick {} │ GeckoTerminal OHLCV + Jupiter probe",
-                app.timeframe.label(),
-                app.tick
-            )),
+            Span::raw(format!(" │ [{}] │ tick {} │ ", app.timeframe.label(), app.tick)),
+            Span::styled("⬢", Style::default().fg(X_E23667).add_modifier(Modifier::BOLD)),
+            Span::raw(" OHLCV + "),
+            Span::styled("✧", Style::default().fg(X_AC36E2).add_modifier(Modifier::BOLD)),
+            Span::raw(" probe │ "),
+            Span::styled("✿", Style::default().fg(X_C836E2).add_modifier(Modifier::BOLD)),
+            Span::raw(" "),
+            Span::styled("⬡", Style::default().fg(X_E25936).add_modifier(Modifier::BOLD)),
+            Span::raw(" "),
+            Span::styled("◈", Style::default().fg(X_E27B36).add_modifier(Modifier::BOLD)),
         ]))
         .style(Style::default().fg(Color::DarkGray)),
         outer[5],


### PR DESCRIPTION
NASH, SOL/POOL, pump.fun, GeckoTerminal, Jupiter, DexScreener, NASH Portal, Plurigrid → . Each proper-name display becomes its colored sigil. Both  (ratzilla) and  (ratatui) get the treatment symmetrically.

| was | now | hex | sigil |
|---|---|---|---|
| NASH |  |  | ◆ token chip, price-bar pill, ticker |
| SOL / POOL |  |  | ◇ native price |
| pump.fun |  |  | ✦ launch venue |
| GeckoTerminal |  |  | ⬢ OHLCV source, loading + footer |
| Jupiter |  |  | ✧ fast price probe, status, footer |
| DexScreener |  |  | ✿ aux feed, status, footer |
| Plurigrid |  |  | ⬡ federation, footer |
| NASH Portal |  |  | ◈ app glyph, HTML title, footer |

 → ,  → . API URLs preserved (functional, not display). Both packages  clean.

Out of scope for this PR (intentional, easy to extend): ,  package names, struct identifiers (, , , ),  button text,  link.